### PR TITLE
Added fast flag and now using doubles as default

### DIFF
--- a/examples/calc_e.vlp
+++ b/examples/calc_e.vlp
@@ -8,7 +8,7 @@ recursive_calc_e = (e, n) => {
     n == 0 -> :> e
 
     # get next term (working backwards)
-    term = 1.0 / ~factorial(n)
+    term = 1.0 / factorial(n).0
 
     # add onto result
     :> @(e + term, n - 1)

--- a/examples/test.vlp
+++ b/examples/test.vlp
@@ -1,11 +1,21 @@
+# a jungle of random tests
+
+# testing compound assignment operators
 a = 3
 a += 2
 a /= 5
 
 b = 2.5
 b *= 4.0
-b -= ~a
+b -= a.5  # conversion
 
-f = () => a
+f = () => ~b  # conversion
 
-:> [b, 1 > 0, !(~5 == 5.0), [1.0, 2, [3.0, 4]], 1.0 / 3.0, f(), f, [f]]
+c = [1.0, 2, [3.0, 4]]  # tuples
+
+[d, _, e] = c  # tuple decomposition
+
+g = (-2)..2  # ranges
+
+# printing various types, float precision
+:> [b, 1 > 0, !(5 == ~5.0), [1.0, 2, [3.0, 4]], 1.0 / 3.0, f(), f, [f], g[1]]

--- a/volpe/__main__.py
+++ b/volpe/__main__.py
@@ -3,11 +3,12 @@
 Usage:
     volpe -h | --help
     volpe add-path
-    volpe <file_path> [-v | --verbose]
+    volpe <file_path> [-v | --verbose] [-f | --fast]
 
 Options:
     -h --help     Show this screen.
     -v --verbose  Print out the parsed tree and code.
+    -f --fast     Use 32 bit instead of 64 bit for floating point numbers.
 """
 
 import os
@@ -50,13 +51,13 @@ def install():
     
 
 
-def compile_and_run(file_path, verbose=False):
+def compile_and_run(file_path, verbose=False, fast=False):
     from run_volpe import run
 
     assert file_path.split(".")[-1] == "vlp", "Volpe files have the file ending .vlp"
     assert os.path.exists(file_path), f"Could not find file: {file_path}"
 
-    run(file_path, verbose=verbose)
+    run(file_path, verbose=verbose, fast=fast)
 
 
 if __name__ == '__main__':
@@ -67,4 +68,4 @@ if __name__ == '__main__':
     if args["add-path"]:
         install()
     else:
-        compile_and_run(args["<file_path>"], args["--verbose"])
+        compile_and_run(args["<file_path>"], args["--verbose"], args["--fast"])

--- a/volpe/annotate_utils.py
+++ b/volpe/annotate_utils.py
@@ -3,7 +3,7 @@ from typing import Dict
 from llvmlite import ir
 
 from tree import TypeTree
-from volpe_types import VolpeTuple, int1, int32, flt32, pint8
+from volpe_types import VolpeTuple, int1, int32, flt32, flt64, pint8
 
 
 def logic(self, tree: TypeTree):
@@ -25,7 +25,7 @@ def math(self, tree: TypeTree):
     assert ret0 == ret1, "types need to match for math operations"
     if ret0 == int32:
         tree.data = tree.data + "_int"
-    elif ret0 == flt32:
+    elif ret0 == flt32 or ret0 == flt64:
         tree.data = tree.data + "_flt"
     else:
         raise AssertionError("math operations only work for integers and floats")
@@ -36,7 +36,7 @@ def unary_math(self, tree: TypeTree):
     ret = self.visit_children(tree)[0]
     if ret == int32:
         tree.data = tree.data + "_int"
-    elif ret == flt32:
+    elif ret == flt32 or ret == flt64:
         tree.data = tree.data + "_flt"
     else:
         raise AssertionError("unary math operations only work for integers and floats")
@@ -65,7 +65,7 @@ def comp(self, tree: TypeTree):
     assert ret0 == ret1, "types need to match for comparisons"
     if ret0 == int32:
         tree.data = tree.data + "_int"
-    elif ret0 == flt32:
+    elif ret0 == flt32 or ret0 == flt64:
         tree.data = tree.data + "_flt"
     else:
         raise AssertionError("comparisons only work for integers and floats")

--- a/volpe/compile.py
+++ b/volpe/compile.py
@@ -4,7 +4,7 @@ import llvmlite.binding as llvm
 
 
 # All these initializations are required for code generation!
-from volpe_types import int1, int32, flt32, VolpeTuple, Closure
+from volpe_types import int1, int32, flt32, flt64, VolpeTuple, Closure
 
 llvm.initialize()
 llvm.initialize_native_target()
@@ -59,5 +59,7 @@ def determine_c_type(volpe_type, depth=0):
         return c_int32
     elif volpe_type == flt32:
         return c_float
+    elif volpe_type == flt64:
+        return c_double
     else:
         return None

--- a/volpe/run_volpe.py
+++ b/volpe/run_volpe.py
@@ -13,7 +13,7 @@ from tree import TypeTree
 from volpe_types import pint8, int32, VolpeTuple, target_data, Closure, copy_func, free_func
 
 
-def volpe_llvm(tree: TypeTree, verbose=False):
+def volpe_llvm(tree: TypeTree, verbose=False, fast=False):
     if verbose:
         print(tree.pretty())
 
@@ -22,7 +22,7 @@ def volpe_llvm(tree: TypeTree, verbose=False):
 
     func_type = Closure(scope, {}, [], tree)
     func_type.checked = True
-    AnnotateScope(tree, func_type.get_scope, {}, func_ret(func_type, []))
+    AnnotateScope(tree, func_type.get_scope, {}, func_ret(func_type, []), fast=fast)
 
     if verbose:
         print(tree.pretty())
@@ -39,7 +39,7 @@ def volpe_llvm(tree: TypeTree, verbose=False):
     closure = func_type([func, c_func, f_func, ir.Undefined])
 
     with build_func(func) as (b, args):
-        LLVMScope(b, tree, {"@": closure}, b.ret)
+        LLVMScope(b, tree, {"@": closure}, b.ret, fast=fast)
 
     with build_func(c_func) as (b, args):
         b.ret(pint8(ir.Undefined))
@@ -68,7 +68,7 @@ def volpe_llvm(tree: TypeTree, verbose=False):
     # return scope.visit(tree)
 
 
-def run(file_path, verbose=False):
+def run(file_path, verbose=False, fast=False):
     base_path = path.dirname(__file__)
     path_to_lark = path.abspath(path.join(base_path, "volpe.lark"))
     with open(path_to_lark) as lark_file:
@@ -76,5 +76,5 @@ def run(file_path, verbose=False):
     with open(file_path) as vlp_file:
         parsed_tree = volpe_parser.parse(vlp_file.read())
     # print(parsed_tree.pretty())
-    volpe_llvm(parsed_tree, verbose)
+    volpe_llvm(parsed_tree, verbose=verbose, fast=fast)
     # llvm_ir()


### PR DESCRIPTION
Both the `AnnotateScope` and the `LLVMScope` have access to whether the `--fast` flag was used with `self.fast`.