### PR TITLE
More info in errors

### DIFF
--- a/volpe/annotate.py
+++ b/volpe/annotate.py
@@ -4,8 +4,8 @@ from lark.visitors import Interpreter
 from lark import Token
 from unification import var, unify
 
-from annotate_utils import logic, unary_logic, math, unary_math, math_assign, comp, shape, volpe_assert
-from tree import TypeTree
+from annotate_utils import logic, unary_logic, math, unary_math, math_assign, comp, shape
+from tree import TypeTree, volpe_assert
 from volpe_types import (
     int64,
     flt64,

--- a/volpe/annotate.py
+++ b/volpe/annotate.py
@@ -42,10 +42,10 @@ class AnnotateScope(Interpreter):
         tree.return_type = getattr(self, tree.data)(tree)
         return tree.return_type
 
-    def get_scope(self, name):
+    def get_scope(self, name, tree: TypeTree):
         if name in self.local_scope:
             return self.local_scope[name]
-        return self.scope(name)
+        return self.scope(name, tree)
 
     def block(self, tree: TypeTree):
         self.rules = AnnotateScope(tree, self.get_scope, self.rules, var()).rules
@@ -63,11 +63,11 @@ class AnnotateScope(Interpreter):
 
         tree.outside_used = set()
 
-        def scope(name):
+        def scope(name, t_tree: TypeTree):
             if name == "@":
                 return closure
             tree.outside_used.add(name)
-            return self.get_scope(name)
+            return self.get_scope(name, t_tree)
 
         self.rules = AnnotateScope(tree.children[1], scope, self.rules, closure.ret_type,
                                    (closure.arg_type, tree.children[0])).rules
@@ -86,7 +86,7 @@ class AnnotateScope(Interpreter):
         return int1
 
     def symbol(self, tree: TypeTree):
-        return self.get_scope(tree.children[0].value)
+        return self.get_scope(tree.children[0].value, tree)
 
     def assign(self, tree: TypeTree):
         volpe_assert(self.unify(shape(self, self.local_scope, tree.children[0]), self.visit(tree.children[1])), "assign error", tree)

--- a/volpe/annotate_utils.py
+++ b/volpe/annotate_utils.py
@@ -1,6 +1,6 @@
 from unification import var
 
-from tree import TypeTree
+from tree import TypeTree, volpe_assert
 from volpe_types import int1, VolpeObject
 
 
@@ -71,13 +71,3 @@ def shape(self, scope: dict, tree: TypeTree):
     tree.return_type = var()
     scope[tree.children[0].value] = tree.return_type
     return tree.return_type
-
-
-class VolpeError(Exception):
-    def __init__(self, message: str, tree: TypeTree):
-        error_message = message + f", line: {tree.meta.line}"
-        super().__init__(error_message)
-
-def volpe_assert(condition: bool, message: str, tree: TypeTree):
-    if not condition:
-        raise VolpeError(message, tree)

--- a/volpe/builder.py
+++ b/volpe/builder.py
@@ -3,6 +3,7 @@ from typing import Callable
 from lark.visitors import Interpreter
 from llvmlite import ir
 
+from annotate_utils import volpe_assert
 from builder_utils import write_environment, free_environment, options, \
     read_environment, tuple_assign, copy, copy_environment, build_closure, free, math, comp, unary_math, \
     check_list_index
@@ -38,7 +39,7 @@ class LLVMScope(Interpreter):
 
     def visit(self, tree: TypeTree):
         value = getattr(self, tree.data)(tree)
-        assert not self.builder.block.is_terminated, "dead code is not allowed"
+        volpe_assert(not self.builder.block.is_terminated, "dead code is not allowed", tree)
         return value
 
     def visit_unsafe(self, tree: TypeTree):

--- a/volpe/builder.py
+++ b/volpe/builder.py
@@ -3,11 +3,10 @@ from typing import Callable
 from lark.visitors import Interpreter
 from llvmlite import ir
 
-from annotate_utils import volpe_assert
 from builder_utils import write_environment, free_environment, options, \
     read_environment, tuple_assign, copy, copy_environment, build_closure, free, math, comp, unary_math, \
     check_list_index
-from tree import TypeTree
+from tree import TypeTree, volpe_assert
 from volpe_types import int1, int64, flt64, target_data, pint8, unwrap
 
 

--- a/volpe/builder_utils.py
+++ b/volpe/builder_utils.py
@@ -23,7 +23,7 @@ def math(self, tree: TypeTree):
 def unary_math(self, tree: TypeTree):
     values = self.visit_children(tree)
     t = unwrap(tree.return_type)
-    if t == int64 or t == char:
+    if t == int64:
         return getattr(self, tree.data + "_int")(values)
     if t == flt64:
         return getattr(self, tree.data + "_flt")(values)

--- a/volpe/builder_utils.py
+++ b/volpe/builder_utils.py
@@ -3,10 +3,9 @@ from typing import List, Iterable
 
 from llvmlite import ir
 
-from tree import TypeTree
+from tree import TypeTree, volpe_assert, VolpeError
 from volpe_types import target_data, VolpeObject, VolpeClosure, copy_func, free_func, VolpeList, \
     pint8, int64, int32, flt64, char, unwrap
-from annotate_utils import VolpeError, volpe_assert
 
 
 def math(self, tree: TypeTree):

--- a/volpe/run_volpe.py
+++ b/volpe/run_volpe.py
@@ -97,7 +97,14 @@ def run(file_path, verbose=False, show_time=False):
     path_to_lark = path.abspath(path.join(base_path, "volpe.lark"))
     volpe_parser = get_parser(path_to_lark)
     with open(file_path) as vlp_file:
-        parsed_tree = volpe_parser.parse(vlp_file.read())
+        try:
+            parsed_tree = volpe_parser.parse(vlp_file.read())
+        except Exception as err:
+            if verbose:
+                traceback.print_exc()
+            else:
+                print(err)
+            exit()
     # put file_path inside tree.meta so that VolpeError can print code blocks
     for tree in parsed_tree.iter_subtrees():
         tree.meta.file_path = file_path

--- a/volpe/run_volpe.py
+++ b/volpe/run_volpe.py
@@ -98,9 +98,7 @@ def run(file_path, verbose=False, show_time=False):
     volpe_parser = get_parser(path_to_lark)
     with open(file_path) as vlp_file:
         parsed_tree = volpe_parser.parse(vlp_file.read())
-    # set the file_path for VolpeErrors
-    VolpeError.file_path = file_path
-    # print(parsed_tree.pretty())
+    # put file_path inside tree.meta so that VolpeError can print code blocks
+    for tree in parsed_tree.iter_subtrees():
+        tree.meta.file_path = file_path
     volpe_llvm(parsed_tree, verbose=verbose, show_time=show_time, more_verbose=verbose)
-    # llvm_ir()
-

--- a/volpe/run_volpe.py
+++ b/volpe/run_volpe.py
@@ -98,6 +98,8 @@ def run(file_path, verbose=False, show_time=False):
     volpe_parser = get_parser(path_to_lark)
     with open(file_path) as vlp_file:
         parsed_tree = volpe_parser.parse(vlp_file.read())
+    # set the file_path for VolpeErrors
+    VolpeError.file_path = file_path
     # print(parsed_tree.pretty())
     volpe_llvm(parsed_tree, verbose=verbose, show_time=show_time, more_verbose=verbose)
     # llvm_ir()

--- a/volpe/run_volpe.py
+++ b/volpe/run_volpe.py
@@ -21,10 +21,10 @@ def volpe_llvm(tree: TypeTree, verbose=False, show_time=False, more_verbose=Fals
     closure = VolpeClosure(VolpeObject(dict()), var())
     arg_scope = {"@": closure}
 
-    def scope(name):
+    def scope(name, tree: TypeTree):
         if name in arg_scope:
             return arg_scope[name]
-        raise VolpeError(f"variable `{name}` not found")
+        raise VolpeError(f"variable `{name}` not found", tree)
 
     try:
         rules = AnnotateScope(tree, scope, dict(), closure.ret_type).rules
@@ -33,7 +33,7 @@ def volpe_llvm(tree: TypeTree, verbose=False, show_time=False, more_verbose=Fals
             traceback.print_exc()
         else:
             print(err)
-        exit()
+        return
 
     for t in tree.iter_subtrees():
         t.return_type = reify(t.return_type, rules)
@@ -68,7 +68,7 @@ def volpe_llvm(tree: TypeTree, verbose=False, show_time=False, more_verbose=Fals
                 traceback.print_exc()
             else:
                 print(err)
-            exit()
+            return
 
     if more_verbose:
         print(module)
@@ -93,7 +93,7 @@ def run(file_path, verbose=False, show_time=False):
                 traceback.print_exc()
             else:
                 print(err)
-            exit()
+            return
     # put file_path inside tree.meta so that VolpeError can print code blocks
     for tree in parsed_tree.iter_subtrees():
         tree.meta.file_path = file_path

--- a/volpe/tree.py
+++ b/volpe/tree.py
@@ -12,15 +12,13 @@ class TypeTree(Tree):
 
 
 class VolpeError(Exception):
-    file_path = None
-
     def __init__(self, message: str, tree: Optional[TypeTree]=None):
         if tree is None:
             super().__init__(message)
             return
 
-        if self.file_path is None:
-            # file_path in VolpeError was not initialized
+        if not hasattr(tree.meta, "file_path"):
+            # file_path in tree.meta has not been initialized
             super().__init__(message + f", line: {tree.meta.line}")
             return
 
@@ -29,7 +27,7 @@ class VolpeError(Exception):
         last_line = tree.meta.end_line
         spacing = last_line // 10
 
-        with open(self.file_path, "r") as f:
+        with open(tree.meta.file_path, "r") as f:
             text = f.readlines()    
             for i, line in enumerate(text[first_line-1 : last_line], first_line):
                 padding = " " * (spacing - i // 10)

--- a/volpe/tree.py
+++ b/volpe/tree.py
@@ -25,12 +25,12 @@ class VolpeError(Exception):
         # Pretty error printing that shows the code block
         first_line = tree.meta.line
         last_line = tree.meta.end_line
-        spacing = last_line // 10
+        spacing = len(str(last_line))
 
         with open(tree.meta.file_path, "r") as f:
             text = f.readlines()    
             for i, line in enumerate(text[first_line-1 : last_line], first_line):
-                padding = " " * (spacing - i // 10)
+                padding = " " * (spacing - len(str(i)))
                 message += f"\n{padding}{i}| {line.rstrip()}"
 
         super().__init__(message)

--- a/volpe/tree.py
+++ b/volpe/tree.py
@@ -12,9 +12,29 @@ class TypeTree(Tree):
 
 
 class VolpeError(Exception):
+    file_path = None
+
     def __init__(self, message: str, tree: Optional[TypeTree]=None):
-        if tree is not None:
-            message += f", line: {tree.meta.line}"
+        if tree is None:
+            super().__init__(message)
+            return
+
+        if self.file_path is None:
+            # file_path in VolpeError was not initialized
+            super().__init__(message + f", line: {tree.meta.line}")
+            return
+
+        # Pretty error printing that shows the code block
+        first_line = tree.meta.line
+        last_line = tree.meta.end_line
+        spacing = last_line // 10
+
+        with open(self.file_path, "r") as f:
+            text = f.readlines()    
+            for i, line in enumerate(text[first_line-1 : last_line], first_line):
+                padding = " " * (spacing - i // 10)
+                message += f"\n{padding}{i}| {line.rstrip()}"
+
         super().__init__(message)
 
 def volpe_assert(condition: bool, message: str, tree: Optional[TypeTree]=None):

--- a/volpe/tree.py
+++ b/volpe/tree.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from lark import Tree
 
 
@@ -8,3 +9,14 @@ class TypeTree(Tree):
         if self.return_type is not None:
             return f'{self.data}: {self.return_type}'
         return self.data
+
+
+class VolpeError(Exception):
+    def __init__(self, message: str, tree: Optional[TypeTree]=None):
+        if tree is not None:
+            message += f", line: {tree.meta.line}"
+        super().__init__(message)
+
+def volpe_assert(condition: bool, message: str, tree: Optional[TypeTree]=None):
+    if not condition:
+        raise VolpeError(message, tree)


### PR DESCRIPTION
I am unsure about whether it belongs in `annotate_utils`, but I didn't want to make a new file just for one class and one function.

I also catch the error so the trace-back doesn't get printed. It was useful in the past because it at least told you the name of the function that the error was coming from, but with the extra line info it doesn't seem necessary.

I tried to make it easy to adjust in the future. You would only have to edit VolpeError to print more information (maybe the code snippet).