### PR TITLE
Added optimization passes

### DIFF
--- a/volpe/compile.py
+++ b/volpe/compile.py
@@ -32,8 +32,7 @@ def compile_and_run(llvm_ir, result_type, more_verbose=False, show_time=False, c
     mod.triple = llvm.get_process_triple()
     mod.verify()
 
-    # Optimizations
-
+    # Configure optimization pass manager builder
     # https://llvmlite.readthedocs.io/en/latest/user-guide/binding/optimization-passes.html#llvmlite.binding.PassManagerBuilder
     pm_builder = llvm.PassManagerBuilder()
     pm_builder.disable_unroll_loops = False
@@ -46,13 +45,14 @@ def compile_and_run(llvm_ir, result_type, more_verbose=False, show_time=False, c
     pm = llvm.ModulePassManager()
     pm_builder.populate(pm)
 
-    # target specific optimizations
+    # Target specific optimizations
     target_machine.add_analysis_passes(pm)
     
     if more_verbose:
         print("\nBefore optimization\n")
         print(mod)
 
+    # Run the optimization passes
     pm.run(mod)
 
     if more_verbose:

--- a/volpe/run_volpe.py
+++ b/volpe/run_volpe.py
@@ -50,10 +50,7 @@ def volpe_llvm(tree: TypeTree, verbose=False, show_time=False, more_verbose=Fals
 
         LLVMScope(b, tree, scope, ret, None)
 
-    if more_verbose:
-        print(module)
-
-    compile_and_run(str(module), tree.return_type, show_time, console)
+    compile_and_run(str(module), tree.return_type, more_verbose=more_verbose, show_time=show_time, console=console)
 
 
 def get_parser(path_to_lark):


### PR DESCRIPTION
Turns out we weren't using the full optimising power that LLVM offers.

Unfortunately `llvmlite.binding.ModulePassManager.run` doesn't seem to always return `False` when no changes are made, and we could get stuck in an [infinite loop](https://github.com/LHolten/Volpe/compare/master...ViliamVadocz:optimization?expand=1#diff-4d8f1ce67375d5dd3599cdb53cdcaffcR46). I used a workaround of comparing the modules for each run, but I suspect this could be slow with large files. We could also cap the pass count to some constant, but I don't want to limit how much we can optimise.