### PR TITLE
Added support for Python 3.6 (also improved timing of code)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Installation
 
-1. You need Python 3.7.0 or higher. [Install here.](https://www.python.org/downloads/)
+1. You need Python 3.6.0 or higher, although we recommend at least 3.7.0. [Install here.](https://www.python.org/downloads/)
 2. You need pip, the Python package manager. It should come pre-installed with Python.
 3. Install the needed packages by running `pip install -r requirements.txt` from the root directory.
 4. Optionally add Volpe to path with `python volpe add-path`. This means you can use `volpe file_name.vlp` anywhere (notice the missing `python`).

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 docopt~=0.6.2
-lark-parser~=0.8.1
-llvmlite~=0.33.0
+lark-parser~=0.9.0
+llvmlite~=0.34.0
+dataclasses~=0.7; python_version == '3.6'

--- a/volpe/__main__.py
+++ b/volpe/__main__.py
@@ -60,7 +60,7 @@ def compile_and_run(file_path, verbose=False, show_time=False, console=False):
 
 
 if __name__ == '__main__':
-    assert version_info >= (3, 7, 0), "You need Python 3.7 or higher."
+    assert version_info >= (3, 6, 0), "You need Python 3.6 or higher."
 
     args = docopt(__doc__)
 

--- a/volpe/compile.py
+++ b/volpe/compile.py
@@ -115,4 +115,4 @@ def compile_and_run(llvm_ir, result_type, more_verbose=False, show_time=False, c
                 print(f"average time: {nanoseconds:.3f} ns")
         else:
             print("ran the code once")
-            print(f"time: {(end_time - start_time) / ticks_in_sec:3f} s")
+            print(f"time: {(end_time - start_time) / ticks_in_sec:.3f} s")

--- a/volpe/compile.py
+++ b/volpe/compile.py
@@ -104,7 +104,7 @@ def compile_and_run(llvm_ir, result_type, more_verbose=False, show_time=False, c
     if show_time:
         if count > 1:
             print(f"ran the code {count} times")
-            nanoseconds = MEASUREMENT_TIME / count * (1E9 / ticks_in_sec) 
+            nanoseconds = (end_time - start_time) / count * (1E9 / ticks_in_sec) 
             if nanoseconds > 1E9:
                 print(f"average time: {nanoseconds / 1E9:.3f} s")
             elif nanoseconds > 1E6:

--- a/volpe/compile.py
+++ b/volpe/compile.py
@@ -1,10 +1,22 @@
 import io
-import time
 from ctypes import CFUNCTYPE, POINTER, byref
 
 import llvmlite.binding as llvm
 
 from volpe_repr import determine_c_type, ENCODING
+
+import time
+from sys import version_info
+
+# use nanosecond perf_counter if available
+if version_info >= (3, 7, 0):
+    perf_counter = time.perf_counter_ns
+    ticks_in_sec = 1E9
+else:
+    perf_counter = time.perf_counter
+    ticks_in_sec = 1
+
+MEASUREMENT_TIME = 5.0 * ticks_in_sec
 
 # All these initializations are required for code generation!
 llvm.initialize()
@@ -72,10 +84,16 @@ def compile_and_run(llvm_ir, result_type, more_verbose=False, show_time=False, c
     c_type = determine_c_type(result_type)
     func = CFUNCTYPE(None, POINTER(c_type))(func_ptr)
     res = c_type()
-
-    start_time = time.perf_counter_ns()
-    func(byref(res))
-    end_time = time.perf_counter_ns()
+    
+    if show_time:
+        count = 0
+        start_time = perf_counter()
+        while perf_counter() - start_time < MEASUREMENT_TIME:
+            func(byref(res))
+            count += 1
+        end_time = perf_counter()
+    else:
+        func(byref(res))
 
     if hasattr(res, "value"):
         res = res.value
@@ -84,8 +102,17 @@ def compile_and_run(llvm_ir, result_type, more_verbose=False, show_time=False, c
     print("main() =", repr(res))
     
     if show_time:
-        time_taken = end_time - start_time
-        if time_taken > 100000:
-            print(f"time = {time_taken/1E9}s")
+        if count > 1:
+            print(f"ran the code {count} times")
+            nanoseconds = MEASUREMENT_TIME / count * (1E9 / ticks_in_sec) 
+            if nanoseconds > 1E9:
+                print(f"average time: {nanoseconds / 1E9:.3f} s")
+            elif nanoseconds > 1E6:
+                print(f"average time: {nanoseconds / 1E6:.3f} ms")
+            elif nanoseconds > 1E3:
+                print(f"average time: {nanoseconds / 1E3:.3f} µs")
+            else:
+                print(f"average time: {nanoseconds:.3f} ns")
         else:
-            print(f"time = {time_taken}ns")
+            print("ran the code once")
+            print(f"time: {(end_time - start_time) / ticks_in_sec:3f} s")


### PR DESCRIPTION
The only things which were not supported were `dataclasses` and `time.perf_counter_ns()`, so I added a dependency to `requirements.txt` with a backport of `dataclasses` and I changed how timing works so that it only used nanoseconds when it was available. It also reruns the code as many times as possible within 5 seconds to get an average time.