### PR TITLE
Added chained comparison

### DIFF
--- a/volpe/annotate.py
+++ b/volpe/annotate.py
@@ -5,7 +5,7 @@ from lark.visitors import Interpreter
 from lark import Token
 from copy import deepcopy
 
-from annotate_utils import logic, unary_logic, math, unary_math, math_assign, comp, assign
+from annotate_utils import logic, unary_logic, math, unary_math, math_assign, comp, chain_comp, assign
 from tree import TypeTree, volpe_assert, VolpeError, get_obj_key_value
 from volpe_types import int64, flt64, char, VolpeObject, VolpeClosure, VolpeArray, int1
 from version_dependent import is_ascii
@@ -178,6 +178,7 @@ class AnnotateScope(Interpreter):
     mod_assign = math_assign
 
     # Comparison
+    chain_comp = chain_comp
     equals = comp
     not_equals = comp
     greater = comp

--- a/volpe/annotate_utils.py
+++ b/volpe/annotate_utils.py
@@ -1,4 +1,4 @@
-from tree import TypeTree, volpe_assert, get_obj_key_value
+from tree import TypeTree, volpe_assert, VolpeError, get_obj_key_value
 from volpe_types import int1, VolpeObject, VolpeArray, is_flt, is_int, is_char, int1_like
 
 
@@ -37,6 +37,50 @@ def math_assign(self, tree: TypeTree):
     tree.children[1] = TypeTree(operation, [symbol, expression], tree.meta)
 
     return self.visit(tree)
+
+
+def chain_comp(self, tree: TypeTree):
+    # Single comparison
+    if len(tree.children) == 3:
+        a, symbol, b = tree.children[0], tree.children[1], tree.children[2]
+        tree.data = symbol_to_data(symbol)
+        tree.children = [a, b]
+        self.visit_children(tree)
+
+    # Chained comparison
+    else:
+        # Separate expressions and comparison operators.
+        expressions = tree.children[::2]
+        comparisons = tree.children[1::2]
+
+        # Generate comparison trees.
+        comp_trees = [
+            TypeTree(symbol_to_data(symbol), [a, b], tree.meta)
+            for symbol, a, b in zip(comparisons, expressions[:-1], expressions[1:])
+        ]
+
+        # Build up nested tree.
+        prev_tree = TypeTree("logic_and", [comp_trees[0], comp_trees[1]], tree.meta)
+        for comp_tree in comp_trees[2:]:
+            prev_tree = TypeTree("logic_and", [prev_tree, comp_tree], tree.meta)
+
+        # Override this node with last.
+        tree.data = prev_tree.data
+        tree.children = prev_tree.children
+
+        self.visit_children(tree)
+
+
+def symbol_to_data(symbol):
+    if symbol == "<=":
+        return "less_equals"
+    if symbol == ">=":
+        return "greater_equals"
+    if symbol == "<":
+        return "less"
+    if symbol == ">":
+        return "greater"
+    raise VolpeError(f"unknown comparison operator `{symbol}` in symbol_to_data")
 
 
 def comp(self, tree: TypeTree):

--- a/volpe/volpe.lark
+++ b/volpe/volpe.lark
@@ -25,10 +25,7 @@ block: (value_ass? _COM? _SEP)* value1 (_COM? _SEP)* _COM?
     | value5 "!=" value6 -> not_equals
 
 ?value6: value7
-    | value6 "<=" value7 -> less_equals
-    | value6 ">=" value7 -> greater_equals
-    | value6 "<" value7 -> less
-    | value6 ">" value7 -> greater
+    | value7 (COMP_TYPE value7)+ -> chain_comp
 
 ?value7: value8
     | value7 "+" value8 -> add
@@ -88,6 +85,7 @@ NEWLINE: (CR? LF)
 
 THIS_FUNC: "@"
 IMPORT: "$" CNAME
+COMP_TYPE: "<=" | ">=" | "<" | ">"
 
 _COM: COMMENT
     | MULTILINE_COMMENT


### PR DESCRIPTION
```
1 < 2 <= 3 >= 2 > 1
```
is equivalent to
```
1 < 2 && 2 <= 3 && 3 >= 2 && 2 > 1
```

I am not sure what exactly happens in this case (whether the function would run twice), but I think optimisation would take care of it and would not to run it twice.
```
0 < expensive_func(3) < 5
```