### PR TITLE
Added new syntax for creating a new constant array, copying another array's size

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -7,21 +7,23 @@ Sometimes examples might become outdated because of syntax changes.
 
 ## Examples that work
 
+- hello
+- sudoku
+- trig
+
+## Examples that don't work
+
+Changes to lists / arrays broke almost everything
+
 - bounces
 - calc_e
 - collatz
 - collisions
 - fizzbuzz (intended as command line app)
 - hello_world
-- hello
 - is_prime
 - list_funcs
 - log
+- mandelbrot
 - ml (warning: large)
 - projectile_sim
-- sudoku
-- trig
-
-## Examples that don't work
-
-- mandelbrot

--- a/volpe/annotate.py
+++ b/volpe/annotate.py
@@ -149,6 +149,12 @@ class AnnotateScope(Interpreter):
         element_type = self.visit(tree.children[0])
         return VolpeArray(element_type, int(tree.children[1].value))
 
+    def constant_list_like(self, tree: TypeTree):
+        tree.data = "constant_list"
+        element_type, parent_array = self.visit_children(tree)
+        volpe_assert(isinstance(parent_array, VolpeArray), "can only get size of arrays", tree)
+        return VolpeArray(element_type, parent_array.count)
+
     def convert_int(self, tree: TypeTree):
         volpe_assert(self.visit(tree.children[0]) == int64, "can only convert int", tree)
         return flt64

--- a/volpe/annotate.py
+++ b/volpe/annotate.py
@@ -112,7 +112,7 @@ class AnnotateScope(Interpreter):
         return char
 
     def string(self, tree: TypeTree):
-        tree.data = "list"
+        tree.data = "array"
         # Evaluate string using Python
         try:
             text = eval(tree.children[0])
@@ -127,30 +127,30 @@ class AnnotateScope(Interpreter):
         self.visit_children(tree)
         return VolpeArray(char, len(tree.children))
 
-    def list_index(self, tree: TypeTree):
+    def array_index(self, tree: TypeTree):
         volpe_array, index = self.visit_children(tree)
         volpe_assert(isinstance(volpe_array, VolpeArray), "can only index arrays", tree)
         volpe_assert(index == int64, "can only index with an integer", tree)
         return volpe_array.element
 
-    def list_size(self, tree: TypeTree):
+    def array_size(self, tree: TypeTree):
         volpe_array = self.visit_children(tree)[0]
         volpe_assert(isinstance(volpe_array, VolpeArray), "can only get size of arrays", tree)
         return int64
 
-    def list(self, tree: TypeTree):
+    def array(self, tree: TypeTree):
         volpe_assert(len(tree.children) > 0, "array needs at least one value", tree)
         element_type = self.visit(tree.children[0])
         for child in tree.children[1:]:
-            volpe_assert(element_type == self.visit(child), "different types in list", tree)
+            volpe_assert(element_type == self.visit(child), "different types in array", tree)
         return VolpeArray(element_type, len(tree.children))
 
-    def constant_list(self, tree: TypeTree):
+    def constant_array(self, tree: TypeTree):
         element_type = self.visit(tree.children[0])
         return VolpeArray(element_type, int(tree.children[1].value))
 
-    def constant_list_like(self, tree: TypeTree):
-        tree.data = "constant_list"
+    def constant_array_like(self, tree: TypeTree):
+        tree.data = "constant_array"
         element_type, parent_array = self.visit_children(tree)
         volpe_assert(isinstance(parent_array, VolpeArray), "can only get size of arrays", tree)
         return VolpeArray(element_type, parent_array.count)

--- a/volpe/annotate_utils.py
+++ b/volpe/annotate_utils.py
@@ -91,13 +91,13 @@ def assign(self, scope: dict, tree: TypeTree, value):
     elif tree.data == "attribute":
         volpe_assert(self.visit(tree) == value, "wrong type in attribute assignment", tree)
 
-    elif tree.data == "list":
+    elif tree.data == "array":
         volpe_assert(isinstance(value, VolpeArray), "can only destructure array")
         volpe_assert(value.count == len(tree.children), "array has wrong length")
         for child in tree.children:
             assign(self, scope, child, value.element)
 
-    elif tree.data == "list_index":
+    elif tree.data == "array_index":
         volpe_assert(self.visit(tree) == value, "wrong type in array assignment", tree)
 
     else:

--- a/volpe/builder.py
+++ b/volpe/builder.py
@@ -97,21 +97,21 @@ class LLVMScope(Interpreter):
         index = list(value.type.type_dict.keys()).index(tree.children[1])
         return self.builder.extract_value(value, index)
 
-    def list_index(self, tree: TypeTree):
+    def array_index(self, tree: TypeTree):
         array_value, i = self.visit_children(tree)
         return self.builder.extract_element(array_value, i)
 
     @staticmethod
-    def list_size(tree: TypeTree):
+    def array_size(tree: TypeTree):
         return int64(tree.children[0].return_type.count)
 
-    def list(self, tree: TypeTree):
+    def array(self, tree: TypeTree):
         array_value = unwrap(tree.return_type)(ir.Undefined)
         for i, ret in enumerate(self.visit_children(tree)):
             array_value = self.builder.insert_element(array_value, ret, int64(i))
         return array_value
 
-    def constant_list(self, tree: TypeTree):
+    def constant_array(self, tree: TypeTree):
         value = self.visit(tree.children[0])
         array_value = unwrap(tree.return_type)(ir.Undefined)
         array_value = self.builder.insert_element(array_value, value, int64(0))

--- a/volpe/builder_utils.py
+++ b/volpe/builder_utils.py
@@ -67,11 +67,11 @@ def assign(self, tree: TypeTree, value):
         # update scope
         assign(self, tree.children[0], value)
 
-    elif tree.data == "list":
+    elif tree.data == "array":
         for i, child in enumerate(tree.children):
             assign(self, child, self.builder.extract_element(value, i))
 
-    elif tree.data == "list_index":
+    elif tree.data == "array_index":
         array, index = self.visit_children(tree)
         new_array = self.builder.insert_element(self.visit(tree.children[0]), value, index)
         assign(self, tree.children[0], new_array)

--- a/volpe/command_line.py
+++ b/volpe/command_line.py
@@ -4,8 +4,8 @@ from builder_utils import build_func, free, options
 from volpe_types import int64, char, VolpeArray, VolpeObject, size, int32, pint8
 
 string_type = VolpeArray(char)
-string_list = VolpeArray(string_type)
-string_obj = VolpeObject({"_0": string_list})
+string_array = VolpeArray(string_type)
+string_obj = VolpeObject({"_0": string_array})
 
 
 def build_main(module, run_func, printf_func):
@@ -29,7 +29,7 @@ def build_main(module, run_func, printf_func):
 
             ret(b.add(phi, int64(1)))
 
-        arguments = string_list.unwrap()(ir.Undefined)
+        arguments = string_array.unwrap()(ir.Undefined)
         arguments = b.insert_value(arguments, pointer, 0)
         arguments = b.insert_value(arguments, num_args, 1)
 

--- a/volpe/volpe.lark
+++ b/volpe/volpe.lark
@@ -41,7 +41,7 @@ block: (value_ass? _COM? _SEP)* value1 (_COM? _SEP)* _COM?
     | "!" value9 -> logic_not
     | "~" value9 -> convert_flt
     | value9 "." INTEGER -> convert_int
-    | "|" value10 "|" -> list_size
+    | "|" value10 "|" -> array_size
     | value9 "::" value10 -> concatenate
 
 ?value10: symbol
@@ -53,12 +53,12 @@ block: (value_ass? _COM? _SEP)* value1 (_COM? _SEP)* _COM?
     | "(" value1 ")" "{" block "}" -> func
     | "{" block "}"
     | "(" value1 ")"
-    | "[" _SEP* value2 ("," _SEP* value2)* _SEP* "]" -> list
-    | "[" _SEP* value1 _SEP* ";" _SEP* INTEGER _SEP* "]" -> constant_list
-    | "[" _SEP* value1 _SEP* ";" _SEP* "|" value10 "|" _SEP* "]" -> constant_list_like
+    | "[" _SEP* value2 ("," _SEP* value2)* _SEP* "]" -> array
+    | "[" _SEP* value1 _SEP* ";" _SEP* INTEGER _SEP* "]" -> constant_array
+    | "[" _SEP* value1 _SEP* ";" _SEP* "|" value10 "|" _SEP* "]" -> constant_array_like
     | value10 "." CNAME -> attribute
     | value10 "(" value1 ")" -> func_call
-    | value10 "[" _SEP* value2 _SEP* "]" -> list_index
+    | value10 "[" _SEP* value2 _SEP* "]" -> array_index
 
 object: item "," (_SEP* item ("," _SEP* item)*)?
 item: (CNAME ":" _SEP*)? value2

--- a/volpe/volpe.lark
+++ b/volpe/volpe.lark
@@ -42,7 +42,6 @@ block: (value_ass? _COM? _SEP)* value1 (_COM? _SEP)* _COM?
     | "~" value9 -> convert_flt
     | value9 "." INTEGER -> convert_int
     | "|" value10 "|" -> array_size
-    | value9 "::" value10 -> concatenate
 
 ?value10: symbol
     | INTEGER -> integer

--- a/volpe/volpe.lark
+++ b/volpe/volpe.lark
@@ -55,6 +55,7 @@ block: (value_ass? _COM? _SEP)* value1 (_COM? _SEP)* _COM?
     | "(" value1 ")"
     | "[" _SEP* value2 ("," _SEP* value2)* _SEP* "]" -> list
     | "[" _SEP* value1 _SEP* ";" _SEP* INTEGER _SEP* "]" -> constant_list
+    | "[" _SEP* value1 _SEP* ";" _SEP* "|" value10 "|" _SEP* "]" -> constant_list_like
     | value10 "." CNAME -> attribute
     | value10 "(" value1 ")" -> func_call
     | value10 "[" _SEP* value2 _SEP* "]" -> list_index


### PR DESCRIPTION
Main change:
- `[ value ; | array | ]` is now allowed

Other:
- Renamed `list` to `array` to close #32
- Removed syntax for concatenation since it is no longer supported
- Updated examples README; reran all examples to see which still work