### PR TITLE
Automatically add to PATH for linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ dmypy.json
 # VSCode
 .vscode/
 *.code-workspace
+
+# Other
+bin/

--- a/README.md
+++ b/README.md
@@ -2,23 +2,23 @@
 
 ## Installation
 
-1. You need Python 3.6.0 or higher, although we recommend at least 3.7.0. [Install here.](https://www.python.org/downloads/)
-2. You need pip, the Python package manager. It should come pre-installed with Python.
-3. Install the needed packages by running `pip install -r requirements.txt` from the root directory.
-4. Optionally add Volpe to path with `python volpe add-path`. This means you can use `volpe file_name.vlp` anywhere (notice the missing `python`).
-    - It will update `volpe.bat` with the correct volpe directory and add it to your PATH.
-    - You can customise the batch file further if you want to use a specific python installation or environment.
+1. Clone the master branch of this repository with `git clone https://github.com/LHolten/Volpe.git`.
+2. You need Python 3.6.0 or higher, although we recommend at least 3.7.0. [Install here.](https://www.python.org/downloads/)
+3. You need pip, the Python package manager. It should come pre-installed with Python.
+4. Install the required Python packages by running `pip install -r requirements.txt`.
+5. Optionally add Volpe to path with `python volpe add-path`. This means you can use `volpe file_name.vlp` anywhere.
+    - It will create a `bin` folder and put either `volpe.bat` (windows) or `volpe` (linux) inside.
+    - The new `bin` folder will be added to PATH and the batch/bash script will have the correct volpe directory.
+    - You can customise the batch/bash file further if you want to use a specific python installation or environment.
 
 ## How to use
 
-Run `volpe --help` to get show the help message. (`-h` for short.)
+Run `volpe --help` to show a help message. (`-h` for short.)
 
 Write your code in a file ending with `.vlp`. Once you are ready to run it, run `volpe <file_path>`.
 `<file_path>` is either a relative path from your working directory or an absolute path.
 
-Use `volpe --verbose` to also see the parsed code. (`-v` for short.)
-
-*If you did not add Volpe to path (step 4 in Installation), prefix all commands with `python`.*
+*If you did not add Volpe to path (step 5 in Installation), prefix all commands with `python`.*
 
 ## Documentation
 

--- a/volpe.bat
+++ b/volpe.bat
@@ -1,3 +1,0 @@
-@echo off
-rem this will be overwritten once you run volpe add-path
-python volpe %*

--- a/volpe/__main__.py
+++ b/volpe/__main__.py
@@ -13,42 +13,63 @@ Options:
 """
 
 import os
-from sys import version_info
+from sys import version_info, platform
 from docopt import docopt
 
 
 def install():
-    # Look up user path in registry.
-    import winreg
-
-    reg_key = winreg.OpenKey(winreg.HKEY_CURRENT_USER, r"Environment")
-    path = winreg.QueryValueEx(reg_key, "Path")[0]
-
     path_to_volpe = os.path.abspath(os.path.dirname(__file__))
     path_to_volpe_root = os.path.dirname(path_to_volpe)
+    path_to_volpe_bin = os.path.join(path_to_volpe_root, "bin")
 
-    # Update the .bat file
-    print("Updating batch file with volpe directory.")
-    with open(os.path.join(path_to_volpe_root, "volpe.bat"), "w") as OPATH:
-        OPATH.writelines(["@echo off\n", f"python {path_to_volpe} %*"])
-    print("=====")
+    path = os.environ["PATH"]
 
-    if path_to_volpe_root in path:
+    if path_to_volpe_bin in path:
         print("Volpe is already on PATH.")
+        return
 
-        if path_to_volpe_root not in os.environ["PATH"]:
-            print("=====")
-            print("Please restart this console for changes to take effect.")
+    if not os.path.isdir(path_to_volpe_bin):
+        os.makedirs(path_to_volpe_bin)
 
-    else:
+    if platform == "win32":
+        # Update the batch file.
+        print("Updating batch file with volpe directory.")
+        batch_file_path = os.path.join(path_to_volpe_bin, "volpe.bat")
+        with open(batch_file_path, "w") as batch_file:
+            batch_file.writelines(["@echo off\n", f"python {path_to_volpe} %*"])
+  
         # Add Volpe path to user path.
-        print(f"Adding {path_to_volpe_root} to user PATH.")
+        print(f"Adding {path_to_volpe_bin} to user PATH.")
         path_including_volpe = path + os.pathsep + path_to_volpe_root
-        print("Setting local user PATH.")
         os.system(f'SETX Path "{path_including_volpe}"')
 
-        print("=====")
         print("Please restart this console for changes to take effect.")
+
+    elif platform == "linux":
+        # Update the bash file.
+        print("Updating bash file with volpe directory.")
+        bash_file_path = os.path.join(path_to_volpe_bin, "volpe")
+        with open(bash_file_path, "w") as bash_file:
+            bash_file.writelines(["#!/bin/bash\n", f"python {path_to_volpe} $@"])
+
+        # Add executable permissions.
+        print("Adding executable permission to bash file with chmod")
+        import stat
+        st = os.stat(bash_file_path)
+        os.chmod(bash_file_path, st.st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+        # Add Volpe path to profile.
+        home = os.path.expanduser("~")
+        profile = os.path.join(home, ".profile")
+        command = f"export PATH=\"$PATH:{path_to_volpe_bin}\""
+        print(f"Adding {command} to {profile}")
+        with open(profile, "a") as profile_file:
+            profile_file.write(f"\n{command}\n")
+
+        print("Please reboot for changes to take effect.")
+
+    else:
+        print(f"Unsupported platform: {platform}\nPlease go tell the developers to fix this or make a contribution.")
 
 
 def run(file_path, verbose=False, show_time=False, console=False):

--- a/volpe/tree.py
+++ b/volpe/tree.py
@@ -31,8 +31,7 @@ class VolpeError(Exception):
 
         # Add type info to error
         types = ", ".join(str(child.return_type) for child in tree.children if isinstance(child, TypeTree))
-        s = "s" if len(tree.children) > 1 else ""
-        message += f"\n  type{s}: {types}"
+        message += f"\n  typing: {types}"
 
         if not hasattr(tree.meta, "file_path"):
             # file_path in tree.meta has not been initialized


### PR DESCRIPTION
Most noticeable change is that `volpe.bat` and `volpe` will now be located in `bin/` after adding to path. This is because I couldn't call a file `volpe` in the same location as the folder `volpe`, and otherwise I couldn't get rid of the file ending on linux and you would have to write `volpe.sh file_name.vlp`.

For linux I append `export PATH="$PATH:path_to_volpe_bin"` to `.profile` which works, although I am not sure if that is a common thing to do on linux. I had trouble getting the right permissions to write files in the usual bin/ locations like `usr/bin/`, which is why I chose to do it this way.

The code is hopefully clearer than before.